### PR TITLE
Intolerance bug fix

### DIFF
--- a/source/scripts/API/utilityFunctions.js
+++ b/source/scripts/API/utilityFunctions.js
@@ -341,7 +341,6 @@ export async function fetchRecipes(recipe_count, offset){
                 // this promise is created to resolve after local
                 // storage is fully populated before resolving the parent promise 
                 let childPromise = new Promise((resolve, reject) => {
-                    let recipes 
                     res["results"].forEach(async r => {
                         await createRecipeObject(r);
                         if (localStorage.length >= res["results"].length) {


### PR DESCRIPTION
Fixed the bug where it wasn't showing recipes after setting the intolerances(possibly in the scenario where user enters our site for the first time). Closes #34 

Code Changes:
1. Added a child promise inside the original promise which `fetchRecipes(...)` was returning.
   - make it wait until the local storage is populated fully.
2. Moved `removeRecipes()` after the local storage is populated. This might affect the time complexity, but this is the best I could come up with. And I don't think there will be a huge amount of `id`s inside the deletedRecipes array. So I think it's fine.