### PR TITLE
Fixed Recipes Not Displaying After Setting Intolerances

### DIFF
--- a/source/scripts/API/utilityFunctions.js
+++ b/source/scripts/API/utilityFunctions.js
@@ -337,15 +337,33 @@ export async function fetchRecipes(recipe_count, offset){
         fetch(reqUrl, options)
             .then(res => res.json())
             .then(res => {
-                res["results"].forEach(r => {
-                    if (deletedRecipes.includes(r["id"])) { 
-                        removeRecipe((r["id"]).toString())
+
+                // Find the expected length of recipes in the local storage
+                let expectedLength = res["results"].length;
+
+                // create local storage items
+                res["results"].forEach(async r => {
+                    await createRecipeObject(r);
+
+                    // Find amount of recipes in the local storage
+                    // filtering out `userData` and `latestSearch`
+                    let localStorageLength = localStorage.length;
+                    if (localStorage.getItem("userData")) {
+                        localStorageLength--;
                     }
-                    else { 
-                        createRecipeObject(r);
-                    } 
+                    if (localStorage.getItem("latestSearch")) {
+                        localStorageLength--;
+                    }
+                    // resolves when expected amount of recipes is met.
+                    if (localStorageLength >= expectedLength) {
+
+                        // remove Recipes in the `deletedRecipes` list
+                        deletedRecipes.forEach(id => {
+                            removeRecipe(id.toString());
+                        });
+                        resolve(true);
+                    }
                 });
-                resolve(true);
             })
             .catch(error => {
                 reject(false);
@@ -459,6 +477,6 @@ export function getLocalStorageRecipes() {
  * @param {number} id - id for the local storage item
  * @param {Object} recipeObject - a JSON recipe object
  */ 
-export async function setLocalStorageItem(id, recipeObject) {
+export function setLocalStorageItem(id, recipeObject) {
     localStorage.setItem(id, JSON.stringify(recipeObject));
 }


### PR DESCRIPTION
Fixed the bug where it wasn't showing recipes after setting the intolerances(possibly in the scenario where user enters our site for the first time). 
[Closes #34]

#### Code Changes:
1. Added an `async` keyword to the `forEach` block inside the promise in order to use `await` keyword 
2. Moved `removeRecipes(...)` after the local storage is populated fully. This might affect the time complexity, but this is the best I could come up with. And I don't think there will be a huge amount of ids inside the `deletedRecipes` array. So I think it's fine.
3. Changed `setLocalStorageItem(...)` to be a synchronous function instead of an async one. 
