### PR TITLE
Populate Home-Page When Minimum Recipes Needed Are loaded, Fixed PopulateRecipes

### DIFF
--- a/source/scripts/main.js
+++ b/source/scripts/main.js
@@ -19,7 +19,7 @@ function init(){
         if(intols || intols === ""){
             util.setIntolerances(intols);
         }
-        util.fetchRecipes(util.DEFAULT_RECIPE_NUMBER, 0).then(() => {
+        util.populateRecipes(util.DEFAULT_RECIPE_NUMBER).then(() => {
             createRecipeCards(util.DEFAULT_RECIPE_NUMBER);
         });
     }

--- a/source/scripts/main.js
+++ b/source/scripts/main.js
@@ -20,7 +20,7 @@ function init(){
             util.setIntolerances(intols);
         }
         util.populateRecipes(util.DEFAULT_RECIPE_NUMBER).then(() => {
-            createRecipeCards(util.DEFAULT_RECIPE_NUMBER);
+            createRecipeCards(util.MINIMUM_RECIPE_REQUIRED);
         });
     }
     // else if (window.location.pathname === '/source/homepage.html'){


### PR DESCRIPTION
Additional Fix to #64

Code Changes:

1. Changed `init()` in `main.js`, now it's using `populateRecipes(...)`
2. Added a new `promise` inside `populateRecipes(...)` to resolve when local storage have met amount of recipes requested;
3. Moved remove deleted recipes inside the `populateRecipes()` function after local storage is fully populated
4. Added a helper function named `removeDeletedRecipes()` in `utilityFunctions.js` to remove deleted recipes.
5. Added a variable named `MINIMUM_RECIPE_REQUIRED` inside `utilityFunctions.js`, which is used in homepage to start populating recipes instead of waiting until all the recipes are loaded. 